### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-#Deep Autoencoder with TensorFlow
+# Deep Autoencoder with TensorFlow
 
 <p align="center">
    <img src="filters_1.png" alt="Some First Layer Filters"/>
@@ -7,7 +7,7 @@
 A selection of first layer weight filters learned during the pretraining
 </p>
 
-##Introduction
+## Introduction
 The purpose of this repo is to explore the functionality of Google's recently open-sourced
 "sofware library for numerical computation using data flow graphs", 
 [TensorFlow](https://www.tensorflow.org/). We use the library to train
@@ -16,7 +16,7 @@ a deep autoencoder on the MNIST digit data set. For background and a similar imp
 
 The main training code can be found in [autoencoder.py](https://github.com/cmgreen210/TensorFlowDeepAutoencoder/blob/master/code/ae/autoencoder.py) along with the AutoEncoder class that creates and manages the Variables and Tensors used.
 
-##Docker Setup (CPU version only for the time being)
+## Docker Setup (CPU version only for the time being)
 In order to avoid platform issues it's highly encouraged that you run
 the example code in a [Docker](https://www.docker.com/) container. Follow
 the Docker installation instructions on the website. Then run:
@@ -36,13 +36,13 @@ to explore [TensorBoard](https://www.tensorflow.org/versions/master/how_tos/summ
 <p align="center">
 View of TensorBoard's display of weight and bias parameter progress.
 </p>
-##Customizing
+## Customizing
 You can play around with the run options, including the neural net size and shape, input corruption, learning rates, etc.
 in [flags.py](https://github.com/cmgreen210/TensorFlowDeepAutoencoder/blob/master/code/ae/utils/flags.py).
 
-##Old Setup
+## Old Setup
 It is expected that Python2.7 is installed and your default python version.
-###Ubuntu/Linux
+### Ubuntu/Linux
 ```bash
 $ git clone https://github.com/cmgreen210/TensorFlowDeepAutoencoder
 $ cd TensorFlowDeepAutoencoder
@@ -50,7 +50,7 @@ $ sudo chmod +x setup_linux
 $ sudo ./setup_linux  # If you want GPU version specify -g or --gpu
 $ source venv/bin/activate 
 ```
-###Mac OS X
+### Mac OS X
 ```bash
 $ git clone https://github.com/cmgreen210/TensorFlowDeepAutoencoder
 $ cd TensorFlowDeepAutoencoder
@@ -58,7 +58,7 @@ $ sudo chmod +x setup_mac
 $ sudo ./setup_mac
 $ source venv/bin/activate 
 ```
-##Run
+## Run
 To run the default example execute the following command. 
 NOTE: this will take a very long time if you are running on a CPU as opposed to a GPU
 ```bash
@@ -73,6 +73,6 @@ to explore [TensorBoard](https://www.tensorflow.org/versions/master/how_tos/summ
 <p align="center">
 View of TensorBoard's display of weight and bias parameter progress.
 </p>
-##Customizing
+## Customizing
 You can play around with the run options, including the neural net size and shape, input corruption, learning rates, etc.
 in [flags.py](https://github.com/cmgreen210/TensorFlowDeepAutoencoder/blob/master/code/ae/utils/flags.py).


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
